### PR TITLE
Add showTooltip() as external reference to CircularInstance

### DIFF
--- a/example/example-polar-area.html
+++ b/example/example-polar-area.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+    <title>Chart.js and Dart interop example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.js"></script>
+    <script type="application/dart" src="polar-area.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+    <style type="text/css">
+        div.wrapper {
+            margin: 0 auto;
+            max-width: 600px;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div>
+    <div class="wrapper">
+        <canvas id="canvas" height="400" width="400"></canvas>
+    </div>
+</div>
+</body>
+</html>

--- a/example/polar-area.dart
+++ b/example/polar-area.dart
@@ -1,0 +1,33 @@
+import 'dart:html';
+import 'dart:js' as js;
+
+import 'package:chartjs/chartjs.dart';
+
+void main () {
+  var context = (querySelector('#canvas') as CanvasElement).context2D;
+
+  CircularInstance chart;
+
+  var data = [
+    new CircularChartData(value: 42, color: "#F7464A",highlight: "#FF5A5E", label: "Target"),
+    new CircularChartData(value: 38, color: "#46BFBD",highlight: "#5AD3D1", label: "Current"),
+    new CircularChartData(value: 30, color: "#7A7A7A",highlight: "#00FF00", label: "Average")
+  ];
+
+  PolarAreaChartOptions options = new PolarAreaChartOptions(
+      animationSteps: 20,
+      animationEasing: "easeOutQuant",
+      animateScale: true
+  );
+
+  var settings = Chart.defaults['global'];
+  settings.scaleShowLabels = true;
+  settings.showTooltips = true;
+  settings.tooltipTemplate = '<%= value %>';
+  settings.tooltipEvents = [];
+  settings.onAnimationComplete = js.allowInterop(() {
+    chart.showTooltip(chart.segments);
+  });
+
+  chart = new Chart(context).PolarArea(data, options);
+}

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -279,6 +279,7 @@ class CircularInstance extends ChartInstance {
   external void update();
   external void addData(CircularChartData valuesArray, [num index]);
   external void removeData(num index);
+  external void showTooltip(List<CircularChartData> segments);
   external List<CircularChartData> get segments;
   external set segments(List<CircularChartData> v);
 }


### PR DESCRIPTION
I wanted to have segments always labeled. My example code shows the generally accepted hack for Chart.js, but it depends upon showTooltip() function. So I added it.
