### PR TITLE
Rename toBase64() -> toBase64Image()

### DIFF
--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -1202,8 +1202,8 @@ class Chart {
   external set resize(Func0<dynamic /*{}*/ > v);
   external Func0<dynamic /*{}*/ > get clear;
   external set clear(Func0<dynamic /*{}*/ > v);
-  external Func0<String> get toBase64;
-  external set toBase64(Func0<String> v);
+  external Func0<String> get toBase64Image;
+  external set toBase64Image(Func0<String> v);
   external Func0<dynamic /*{}*/ > get generateLegend;
   external set generateLegend(Func0<dynamic /*{}*/ > v);
   external Func1<dynamic, dynamic /*{}*/ > get getElementAtEvent;


### PR DESCRIPTION
This function was not properly named and just returning `null` everytime. After switching `toBase64()` to `toBase64Image()`, I was able to confirm it worked locally.

```
data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABDYAAAFmCAYAAACWZRocAAAgAElEQ…AAAgggEC/Axka8FSURQAABBBBAAAEEEEAAAQQQQCAxgf8D9AtrCHr/qMUAAAAASUVORK5CYII=
```
@kevmoo