### PR TITLE
Removes redundant "new" while calling constructors & update build instructions in example.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Google Inc.
 Kevin Moore <kevmoo@google.com>
+Abhijeeth Padarthi <rkinabhi@gmail.com>

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,3 +33,4 @@ linter:
     - type_init_formals
     - unrelated_type_equality_checks
     - valid_regexps
+    - unnecessary_new

--- a/example/README.md
+++ b/example/README.md
@@ -2,13 +2,19 @@ An example of using [Chart.js](http://www.chartjs.org/).
 
 This example is ported from [this sample](https://github.com/nnnick/Chart.js/blob/b8691c9581bff0eeecb34f98e678dc045a18f33e/samples/line.html) in the `Chart.js` repository.
 
-To view the example, run `pub serve example` from the root directory of this project – the directory containing `pubspec.yaml`.
+To view the example, run `pub global run webdev serve example` from the root directory of this project – the directory containing `pubspec.yaml`.
 
 ```console
-> pub serve example
-Loading source assets...
-Serving js example on http://localhost:8080
-Build completed successfully
+> pub global run webdev serve example
+Creating build script, took 6940ms
+[INFO] Setting up file watchers completed, took 13ms
+[INFO] Waiting for all file watchers to be ready completed, took 30ms
+[INFO] Reading cached asset graph completed, took 278ms
+[INFO] Checking for updates since last build completed, took 589ms
+[INFO] Running build completed, took 213ms
+[INFO] Caching finalized dependency graph completed, took 233ms
+[INFO] Succeeded after 454ms with 0 outputs (0 actions)
+Serving `example` on http://localhost:8080
 ```
 
-You can view it with Dartium or any other browser.
+You can view it with Chrome or any other browser.

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,22 +8,22 @@ import 'dart:math' as math;
 import 'package:chartjs/chartjs.dart';
 
 void main() {
-  var rnd = new math.Random();
+  var rnd = math.Random();
   var months = <String>['January', 'February', 'March', 'April', 'May', 'June'];
 
-  var data = new LinearChartData(labels: months, datasets: <ChartDataSets>[
-    new ChartDataSets(
+  var data = LinearChartData(labels: months, datasets: <ChartDataSets>[
+    ChartDataSets(
         label: 'My First dataset',
         backgroundColor: 'rgba(220,220,220,0.2)',
         data: months.map((_) => rnd.nextInt(100)).toList()),
-    new ChartDataSets(
+    ChartDataSets(
         label: 'My Second dataset',
         backgroundColor: 'rgba(151,187,205,0.2)',
         data: months.map((_) => rnd.nextInt(100)).toList())
   ]);
 
-  var config = new ChartConfiguration(
-      type: 'line', data: data, options: new ChartOptions(responsive: true));
+  var config = ChartConfiguration(
+      type: 'line', data: data, options: ChartOptions(responsive: true));
 
-  new Chart(querySelector('#canvas') as CanvasElement, config);
+  Chart(querySelector('#canvas') as CanvasElement, config);
 }

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -401,15 +401,14 @@ abstract class ChartLegendOptions {
   external set labels(ChartLegendLabelOptions v);
   external bool get reverse;
   external set reverse(bool v);
-  external factory ChartLegendOptions({
-      bool display,
+  external factory ChartLegendOptions(
+      {bool display,
       String /*'left'|'right'|'top'|'bottom'*/ position,
       bool fullWidth,
       void onClick(MouseEvent event, ChartLegendItem legendItem),
       void onHover(MouseEvent event, ChartLegendItem legendItem),
       ChartLegendLabelOptions labels,
-      bool reverse
-  });
+      bool reverse});
 }
 
 @anonymous
@@ -429,15 +428,14 @@ abstract class ChartLegendLabelOptions {
   external num get padding;
   external set padding(num v);
   external dynamic generateLabels(dynamic chart);
-  external factory ChartLegendLabelOptions({
-      num boxWidth,
+  external factory ChartLegendLabelOptions(
+      {num boxWidth,
       num fontSize,
       String fontStyle,
       dynamic /*String|CanvasGradient|CanvasPattern|List<String>*/ fontColor,
       String fontFamily,
       num padding,
-      dynamic generateLabels(dynamic chart)
-  }); 
+      dynamic generateLabels(dynamic chart)});
 }
 
 @anonymous
@@ -527,12 +525,11 @@ abstract class ChartHoverOptions {
   external bool get intersect;
   external set intersect(bool v);
   external void onHover(dynamic active);
-  external factory ChartHoverOptions({
-      String mode,
+  external factory ChartHoverOptions(
+      {String mode,
       num animationDuration,
       bool intersect,
-      void onHover(dynamic active)
-  }); 
+      void onHover(dynamic active)});
 }
 
 @anonymous
@@ -1093,40 +1090,38 @@ abstract class ChartXAxe implements CommonAxe {
   external set barPercentage(num v);
   external TimeScale get time;
   external set time(TimeScale v);
-  external factory ChartXAxe({
-    String /*'category'|'linear'|'logarithmic'|'time'|'radialLinear'|String*/ type,
-    bool display,
-    String id,
-    bool stacked,
-    String position,
-    TickOptions ticks,
-    GridLineOptions gridLines,
-    num barThickness,
-    ScaleTitleOptions scaleLabel,
-    num categoryPercentage,
-    num barPercentage,
-    TimeScale time
-  });
+  external factory ChartXAxe(
+      {String /*'category'|'linear'|'logarithmic'|'time'|'radialLinear'|String*/ type,
+      bool display,
+      String id,
+      bool stacked,
+      String position,
+      TickOptions ticks,
+      GridLineOptions gridLines,
+      num barThickness,
+      ScaleTitleOptions scaleLabel,
+      num categoryPercentage,
+      num barPercentage,
+      TimeScale time});
 }
 
 /// tslint:disable-next-line no-empty-interface
 @anonymous
 @JS()
 abstract class ChartYAxe implements CommonAxe {
-  external factory ChartYAxe({
-    String /*'category'|'linear'|'logarithmic'|'time'|'radialLinear'|String*/ type,
-    bool display,
-    String id,
-    bool stacked,
-    String position,
-    TickOptions ticks,
-    GridLineOptions gridLines,
-    num barThickness,
-    ScaleTitleOptions scaleLabel,
-    num categoryPercentage,
-    num barPercentage,
-    TimeScale time
-  });
+  external factory ChartYAxe(
+      {String /*'category'|'linear'|'logarithmic'|'time'|'radialLinear'|String*/ type,
+      bool display,
+      String id,
+      bool stacked,
+      String position,
+      TickOptions ticks,
+      GridLineOptions gridLines,
+      num barThickness,
+      ScaleTitleOptions scaleLabel,
+      num categoryPercentage,
+      num barPercentage,
+      TimeScale time});
 }
 
 @anonymous

--- a/lib/src/func.dart
+++ b/lib/src/func.dart
@@ -2,6 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-typedef R Func0<R>();
-typedef R Func1<A, R>(A a);
-typedef R Func1Opt1<A, R>([A a]);
+typedef Func0<R> = R Function();
+typedef Func1<A, R> = R Function(A a);
+typedef Func1Opt1<A, R> = R Function([A a]);


### PR DESCRIPTION
- Reduce verbosity of code by removing redundant `new` while calling constructors.
- added _unnecessary_new_ to lint rules.
- format code.
- update README.md in **example** project with updated instructions to build and serve the application for dart-2. updates made w.r.t [Dart 2 Migration Guide for Web Apps](https://webdev.dartlang.org/dart-2).

