### PR TITLE
Add external factory for LinearTickOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .dart_tool/
 .packages
 .pub/

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -917,6 +917,16 @@ abstract class LinearTickOptions implements TickOptions<num> {
   external set suggestedMin(num v);
   external num get suggestedMax;
   external set suggestedMax(num v);
+
+  external factory LinearTickOptions(
+    bool beginAtZero,
+    num min,
+    num max,
+    num maxTicksLimit,
+    num stepSize,
+    num suggestedMin,
+    num suggestedMax
+  );
 }
 
 @anonymous

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -940,6 +940,11 @@ abstract class LogarithmicTickOptions implements TickOptions<num> {
   external num get max;
   @override
   external set max(num v);
+
+  external factory LogarithmicTickOptions(
+    num min,
+    num max
+  );
 }
 
 /*type ChartColor = string | CanvasGradient | CanvasPattern | string[];*/

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -875,6 +875,30 @@ abstract class TickOptions<T> {
   external set maxTicksLimit(num v);
   external bool get showLabelBackdrop;
   external set showLabelBackdrop(bool v);
+
+  external factory TickOptions({
+    bool autoSkip,
+    bool autoSkipPadding,
+    dynamic Function(dynamic value, dynamic index, dynamic values) callback,
+    bool display,
+    dynamic fontColor,
+    String fontFamily,
+    num fontSize,
+    String fontStyle,
+    num labelOffset,
+    num maxRotation,
+    num minRotation,
+    bool mirror,
+    num padding,
+    bool reverse,
+    dynamic min,
+    dynamic max,
+    dynamic backdropColor,
+    num backdropPaddingX,
+    num backdropPaddingY,
+    num maxTicksLimit,
+    bool showLabelBackdrop
+  });
 }
 
 @anonymous

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -918,7 +918,7 @@ abstract class LinearTickOptions implements TickOptions<num> {
   external num get suggestedMax;
   external set suggestedMax(num v);
 
-  external factory LinearTickOptions(
+  external factory LinearTickOptions({
     bool beginAtZero,
     num min,
     num max,
@@ -926,7 +926,7 @@ abstract class LinearTickOptions implements TickOptions<num> {
     num stepSize,
     num suggestedMin,
     num suggestedMax
-  );
+  });
 }
 
 @anonymous
@@ -941,10 +941,10 @@ abstract class LogarithmicTickOptions implements TickOptions<num> {
   @override
   external set max(num v);
 
-  external factory LogarithmicTickOptions(
+  external factory LogarithmicTickOptions({
     num min,
     num max
-  );
+  });
 }
 
 /*type ChartColor = string | CanvasGradient | CanvasPattern | string[];*/

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -220,6 +220,20 @@ abstract class ChartTooltipCallback {
   external void beforeFooter([List<ChartTooltipItem> item, dynamic data]);
   external void footer([List<ChartTooltipItem> item, dynamic data]);
   external void afterFooter([List<ChartTooltipItem> item, dynamic data]);
+
+  external factory ChartTooltipCallback({
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) beforeTitle,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) title,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) afterTitle,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) beforeBody,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) beforeLabel,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) label,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) afterLabel,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) afterBody,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) beforeFooter,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) footer,
+    void Function([ChartTooltipItem tooltipItem, dynamic data]) afterFooter
+  });
 }
 
 @anonymous

--- a/lib/chartjs.dart
+++ b/lib/chartjs.dart
@@ -949,6 +949,10 @@ abstract class LinearTickOptions implements TickOptions<num> {
   external num get maxTicksLimit;
   @override
   external set maxTicksLimit(num v);
+  @override
+  external dynamic /*String|num*/ callback(
+      dynamic value, dynamic index, dynamic values);
+
   external num get stepSize;
   external set stepSize(num v);
   external num get suggestedMin;
@@ -963,7 +967,8 @@ abstract class LinearTickOptions implements TickOptions<num> {
     num maxTicksLimit,
     num stepSize,
     num suggestedMin,
-    num suggestedMax
+    num suggestedMax,
+    dynamic Function(dynamic value, dynamic index, dynamic values) callback
   });
 }
 


### PR DESCRIPTION
A first contribution to the project, apologies in advance if there is more ceremony to follow outside of CLA.

- Added `external factory` for `LinearTickOptions`.
- Added `external factory` for `LogarithmicTickOptions`.

Would be very happy to quickly address any and all ensuing feedback, as this is presently a blocker for me.

Thank you in advance!